### PR TITLE
Fix HTTP error 400 after @hapi/joi update

### DIFF
--- a/dev-server/routes/tool-default.js
+++ b/dev-server/routes/tool-default.js
@@ -84,7 +84,7 @@ module.exports = {
         query: {
           appendItemToPayload: Joi.string().optional()
         },
-        payload: Joi.object(),
+        payload: Joi.string(),
         options: {
           allowUnknown: true
         }


### PR DESCRIPTION
Since @hapi/joi v16, `Joi.object()` no longer coerces strings automatically, which means that an object passed as string in a query parameter fails the validation.

A simple fix is to use `Joi.string()` instead.

A more complicated fix would be to do the same as we did in Q Server (https://github.com/nzzdev/Q-server/pull/202), but IMHO this would be a bit overkill, since we are not using `Joi.object()` anywhere else in Q Cli.

Fixes #45 