### PR TITLE
(update-item) Send cookie with authenticated requests

### DIFF
--- a/bin/commands/updateItem/helpers.js
+++ b/bin/commands/updateItem/helpers.js
@@ -260,7 +260,7 @@ async function setupConfigFromEnvVars(environment) {
       cookie
     );
 
-    if (!result.accessToken) {
+    if (!result) {
       console.error(
         errorColor(
           `A problem occured while authenticating to the ${environment} environment using environment variables. Please check your credentials and try again.`
@@ -301,12 +301,13 @@ async function authenticate(environment, qServer) {
     cookie
   );
 
-  while (!result.accessToken) {
+  while (!result) {
     console.error(
       errorColor(
         "A problem occured while authenticating. Please check your credentials and try again."
       )
     );
+
     result = await authenticate(environment, qServer);
 
     if (result.accessToken) {
@@ -327,7 +328,7 @@ async function getAccessToken(
   try {
     const response = await fetch(`${qServer}authenticate`, {
       method: "POST",
-      header: {
+      headers: {
         "user-agent": "Q Command-line Tool",
         origin: qServer,
         cookie: cookie,
@@ -337,13 +338,15 @@ async function getAccessToken(
         password: password,
       }),
     });
+
     if (response.ok) {
       const body = await response.json();
       return {
         accessToken: body.access_token,
-        cookie: response.header.cookie,
+        cookie: response.headers.cookie,
       };
     }
+
     return false;
   } catch (error) {
     console.error(

--- a/bin/commands/updateItem/helpers.js
+++ b/bin/commands/updateItem/helpers.js
@@ -192,6 +192,12 @@ function getEnvironments(qConfig, environmentFilter) {
   }
 }
 
+async function setAuthenticationConfig(environment, qServer) {
+  const result = await authenticate(environment, qServer);
+  config.set(`${environment}.accessToken`, result.accessToken);
+  config.set(`${environment}.cookie`, result.cookie);
+}
+
 async function setupConfig(qConfig, environmentFilter, reset) {
   if (reset) {
     config.clear();
@@ -212,16 +218,13 @@ async function setupConfig(qConfig, environmentFilter, reset) {
       config.set(`${environment}.qServer`, qServer);
     }
 
+    const qServer = config.get(`${environment}.qServer`);
     if (!config.get(`${environment}.accessToken`)) {
-      const qServer = config.get(`${environment}.qServer`);
-      const result = await authenticate(environment, qServer);
-      config.set(`${environment}.accessToken`, result.accessToken);
-      config.set(`${environment}.cookie`, result.cookie);
+      await setAuthenticationConfig(environment, qServer);
     }
 
     const accessToken = config.get(`${environment}.accessToken`);
     const cookie = config.get(`${environment}.cookie`);
-    const qServer = config.get(`${environment}.qServer`);
     const isAccessTokenValid = await checkValidityOfAccessToken(
       environment,
       qServer,
@@ -231,10 +234,7 @@ async function setupConfig(qConfig, environmentFilter, reset) {
 
     // Get a new access token in case its not valid anymore
     if (!isAccessTokenValid) {
-      const qServer = config.get(`${environment}.qServer`);
-      const result = await authenticate(environment, qServer);
-      config.set(`${environment}.accessToken`, result.accessToken);
-      config.set(`${environment}.cookie`, result.cookie);
+      await setAuthenticationConfig(environment, qServer);
     }
   }
 

--- a/bin/commands/updateItem/helpers.js
+++ b/bin/commands/updateItem/helpers.js
@@ -14,23 +14,26 @@ const resourcesHelpers = require("./resourcesHelpers.js");
 async function updateItem(item, environment, config, qConfigPath) {
   const qServer = config.get(`${environment.name}.qServer`);
   const accessToken = config.get(`${environment.name}.accessToken`);
-  const existingItem = await getItem(qServer, accessToken, environment);
+  const cookie = config.get(`${environment.name}.cookie`);
+  const existingItem = await getItem(qServer, environment, accessToken, cookie);
   const updatedItem = await getUpdatedItem(
     qServer,
     accessToken,
+    cookie,
     existingItem,
     item,
     environment,
     qConfigPath
   );
-  return await saveItem(qServer, accessToken, updatedItem, environment);
+  return await saveItem(qServer, environment, accessToken, cookie, updatedItem);
 }
 
-async function getItem(qServer, accessToken, environment) {
+async function getItem(qServer, environment, accessToken, cookie) {
   try {
     const response = await fetch(`${qServer}item/${environment.id}`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
+        Cookie: cookie,
       },
     });
     if (response.ok) {
@@ -49,6 +52,7 @@ async function getItem(qServer, accessToken, environment) {
 async function getUpdatedItem(
   qServer,
   accessToken,
+  cookie,
   existingItem,
   item,
   environment,
@@ -64,6 +68,7 @@ async function getUpdatedItem(
     item = await resourcesHelpers.handleResources(
       qServer,
       accessToken,
+      cookie,
       item,
       defaultItem,
       qConfigPath,
@@ -88,7 +93,13 @@ async function getUpdatedItem(
   }
 }
 
-async function saveItem(qServer, accessToken, updatedItem, environment) {
+async function saveItem(
+  qServer,
+  environment,
+  accessToken,
+  cookie,
+  updatedItem
+) {
   try {
     delete updatedItem.updatedDate;
     const response = await fetch(`${qServer}item`, {
@@ -97,6 +108,7 @@ async function saveItem(qServer, accessToken, updatedItem, environment) {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
+        Cookie: cookie,
       },
     });
     if (response.ok) {
@@ -202,23 +214,27 @@ async function setupConfig(qConfig, environmentFilter, reset) {
 
     if (!config.get(`${environment}.accessToken`)) {
       const qServer = config.get(`${environment}.qServer`);
-      const accessToken = await authenticate(environment, qServer);
-      config.set(`${environment}.accessToken`, accessToken);
+      const result = await authenticate(environment, qServer);
+      config.set(`${environment}.accessToken`, result.accessToken);
+      config.set(`${environment}.cookie`, result.cookie);
     }
 
     const accessToken = config.get(`${environment}.accessToken`);
+    const cookie = config.get(`${environment}.cookie`);
     const qServer = config.get(`${environment}.qServer`);
     const isAccessTokenValid = await checkValidityOfAccessToken(
       environment,
       qServer,
-      accessToken
+      accessToken,
+      cookie
     );
 
     // Get a new access token in case its not valid anymore
     if (!isAccessTokenValid) {
       const qServer = config.get(`${environment}.qServer`);
-      const accessToken = await authenticate(environment, qServer);
-      config.set(`${environment}.accessToken`, accessToken);
+      const result = await authenticate(environment, qServer);
+      config.set(`${environment}.accessToken`, result.accessToken);
+      config.set(`${environment}.cookie`, result.cookie);
     }
   }
 
@@ -235,14 +251,16 @@ async function setupConfigFromEnvVars(environment) {
   const username = process.env[`Q_${environmentPrefix}_USERNAME`];
   const password = process.env[`Q_${environmentPrefix}_PASSWORD`];
   if (qServer && username && password) {
-    const accessToken = await getAccessToken(
+    const cookie = config.get(`${environment}.cookie`);
+    const result = await getAccessToken(
       environment,
       qServer,
       username,
-      password
+      password,
+      cookie
     );
 
-    if (!accessToken) {
+    if (!result.accessToken) {
       console.error(
         errorColor(
           `A problem occured while authenticating to the ${environment} environment using environment variables. Please check your credentials and try again.`
@@ -251,7 +269,8 @@ async function setupConfigFromEnvVars(environment) {
       process.exit(1);
     }
 
-    config.set(`${environment}.accessToken`, accessToken);
+    config.set(`${environment}.accessToken`, result.accessToken);
+    config.set(`${environment}.cookie`, result.cookie);
   }
 }
 
@@ -273,36 +292,45 @@ async function authenticate(environment, qServer) {
     }
   );
 
-  let accessToken = await getAccessToken(
+  const cookie = config.get(`${environment}.cookie`);
+  let result = await getAccessToken(
     environment,
     qServer,
     username,
-    password
+    password,
+    cookie
   );
 
-  while (!accessToken) {
+  while (!result.accessToken) {
     console.error(
       errorColor(
         "A problem occured while authenticating. Please check your credentials and try again."
       )
     );
-    accessToken = await authenticate(environment, qServer);
+    result = await authenticate(environment, qServer);
 
-    if (accessToken) {
+    if (result.accessToken) {
       break;
     }
   }
 
-  return accessToken;
+  return result;
 }
 
-async function getAccessToken(environment, qServer, username, password) {
+async function getAccessToken(
+  environment,
+  qServer,
+  username,
+  password,
+  cookie
+) {
   try {
     const response = await fetch(`${qServer}authenticate`, {
       method: "POST",
       header: {
         "user-agent": "Q Command-line Tool",
         origin: qServer,
+        cookie: cookie,
       },
       body: JSON.stringify({
         username: username,
@@ -311,7 +339,10 @@ async function getAccessToken(environment, qServer, username, password) {
     });
     if (response.ok) {
       const body = await response.json();
-      return body.access_token;
+      return {
+        accessToken: body.access_token,
+        cookie: response.header.cookie,
+      };
     }
     return false;
   } catch (error) {
@@ -324,11 +355,17 @@ async function getAccessToken(environment, qServer, username, password) {
   }
 }
 
-async function checkValidityOfAccessToken(environment, qServer, accessToken) {
+async function checkValidityOfAccessToken(
+  environment,
+  qServer,
+  accessToken,
+  cookie
+) {
   try {
     const response = await fetch(`${qServer}user`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
+        Cookie: cookie,
       },
     });
     return response.ok;

--- a/bin/commands/updateItem/resourcesHelpers.js
+++ b/bin/commands/updateItem/resourcesHelpers.js
@@ -126,6 +126,7 @@ function getDefaultItem(schema) {
 async function handleResources(
   qServer,
   accessToken,
+  cookie,
   item,
   defaultItem,
   qConfigPath,
@@ -144,6 +145,7 @@ async function handleResources(
           item[key] = await handleResources(
             qServer,
             accessToken,
+            cookie,
             item[key],
             defaultItemSubtree,
             qConfigPath,
@@ -155,6 +157,7 @@ async function handleResources(
             item = await getResourceMetadata(
               qServer,
               accessToken,
+              cookie,
               resourcePath,
               defaultItem,
               qConfigPath,
@@ -179,6 +182,7 @@ async function handleResources(
 async function getResourceMetadata(
   qServer,
   accessToken,
+  cookie,
   resource,
   fileProperties,
   qConfigPath,
@@ -187,7 +191,7 @@ async function getResourceMetadata(
   const resourcePath = path
     .resolve(path.dirname(qConfigPath), resource)
     .replace(/{id}/g, environment.id);
-  resource = await uploadResource(qServer, accessToken, resourcePath);
+  resource = await uploadResource(qServer, accessToken, cookie, resourcePath);
   const statistic = await stat(resourcePath);
   resource.size = statistic.size;
   resource.type = mimos.path(resourcePath).type;
@@ -204,7 +208,7 @@ async function getResourceMetadata(
   return resource;
 }
 
-async function uploadResource(qServer, accessToken, resourcePath) {
+async function uploadResource(qServer, accessToken, cookie, resourcePath) {
   try {
     if (fs.existsSync(resourcePath)) {
       const form = new FormData();
@@ -212,6 +216,7 @@ async function uploadResource(qServer, accessToken, resourcePath) {
       form.append("file", stream);
       const headers = form.getHeaders();
       headers.Authorization = `Bearer ${accessToken}`;
+      headers.Cookie = cookie;
 
       const response = await fetch(`${qServer}file`, {
         method: "POST",


### PR DESCRIPTION
This PR implements changes to `/authenticate` q-server endpoint. Cookies are now sent with each authenticated request.