### PR TITLE
Release 1.10.0

### DIFF
--- a/bin/commands/qItem/createCustomCodeItem/createCustomCodeItem.js
+++ b/bin/commands/qItem/createCustomCodeItem/createCustomCodeItem.js
@@ -1,0 +1,70 @@
+const schemaService = require('../schemaService.js');
+const configStore = require('../configStore.js');
+const itemService = require('../itemService.js');
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+const errorColor = chalk.red;
+const successColor = chalk.green;
+
+module.exports = async function (command) {
+  try {
+    const qConfigPath = path.resolve(command.config);
+
+    if (!fs.existsSync(qConfigPath)) {
+      console.error(
+        errorColor(
+          "Couldn't find config file named q.config.json in the current directory. Create a config file in the current directory or pass the path to the config file with the option -c <path>"
+        )
+      );
+      process.exit(1);
+    }
+
+    const qConfig = JSON.parse(fs.readFileSync(qConfigPath));
+    const validationResult = schemaService.validateConfig(qConfig, 'createCustomCodeItem');
+
+    if (!validationResult.isValid) {
+      console.error(errorColor(`A problem occured while validating the config file: ${validationResult.errorsText}`));
+      process.exit(1);
+    }
+
+    const environmentName = command.environment;
+    const config = await configStore.setupStore(qConfig, environmentName, command.reset);
+    const items = itemService.getItems(qConfig);
+    const firstItem = items?.[0];
+
+    if (!firstItem) {
+      console.error(errorColor('No items found in the config file.'));
+      process.exit(1);
+    }
+
+    // Create a new custom code item
+    const title = command.title || 'Custom Code item created by Q-cli';
+    const newItem = await itemService.createItem(
+      { title: title, tool: 'custom_code' },
+      { name: environmentName },
+      config
+    );
+
+    if (!newItem) {
+      console.error(errorColor('Failed to create a new custom code item.'));
+      process.exit(1);
+    }
+
+    // Add the new custom code item to the config file
+    qConfig.items[0].environments.push({
+      id: newItem._id,
+      name: environmentName,
+    });
+
+    // Write the updated config file
+    fs.writeFileSync(qConfigPath, JSON.stringify(qConfig, null, 2));
+
+    console.log(
+      successColor(`Successfully added new custom code item with id ${newItem._id} on ${environmentName} environment.`)
+    );
+  } catch (error) {
+    console.error(errorColor(`A problem occured while parsing the config file at ${command.config}.`));
+    console.error(error);
+  }
+};

--- a/bin/commands/qItem/createCustomCodeItem/schema.json
+++ b/bin/commands/qItem/createCustomCodeItem/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Q Config",
+  "description": "Config used by the Q CLI to update items",
+  "type": "object",
+  "properties": {
+    "items": {
+      "description": "Array of Q items",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "environments": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Environment name of Q item"
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Id of Q item"
+                }
+              },
+              "required": ["name", "id"]
+            }
+          },
+          "item": {
+            "type": "object"
+          }
+        },
+        "required": ["environments", "item"]
+      }
+    }
+  },
+  "required": ["items"]
+}

--- a/bin/commands/qItem/schemaService.js
+++ b/bin/commands/qItem/schemaService.js
@@ -25,6 +25,7 @@ async function getToolSchema(qServer, tool) {
 
 function getSchemaPathFor(commandName) {
   const pathFor = {
+    createCustomCodeItem: "./createCustomCodeItem/schema.json",
     copyItem: "./copyItem/copySchema.json",
     updateItem: "./updateItem/updateSchema.json",
   };

--- a/bin/q.js
+++ b/bin/q.js
@@ -8,6 +8,7 @@ const runServer = require("./commands/server.js");
 const bootstrap = require("./commands/bootstrap.js");
 const updateItem = require("./commands/qItem/updateItem/updateItem.js");
 const copyItem = require("./commands/qItem/copyItem/copyItem.js");
+const createCustomCodeItem = require("./commands/qItem/createCustomCodeItem/createCustomCodeItem.js");
 
 async function main() {
   program.version(version).description("Q Toolbox cli");
@@ -183,6 +184,27 @@ async function main() {
     .option("-r, --reset", "reset stored configuration properties")
     .action(async (command) => {
       await copyItem(command);
+    });
+
+  program
+    .command("create-custom-code-item")
+    .description("creates a new q custom code item in the db and adds it to the q config file")
+    .option(
+      "-c, --config [path]",
+      "set config path to q.config.json. defaults to ./q.config.json",
+      `${process.cwd()}/q.config.json`
+    )
+    .option(
+      "-e, --environment [env]",
+      "set environment where the new q custom code item should be created in"
+    )
+    .option(
+      "-t, --title [title]",
+      "set title of the new q custom code item"
+    )
+    .option("-r, --reset", "reset stored configuration properties")
+    .action(async (command) => {
+      await createCustomCodeItem(command);
     });
 
   await program.parseAsync(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-cli",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-cli",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "prettier": "@nzz/et-utils-config-prettier",
   "description": "Cli tool to setup new Q tools, new Q server implementations and start Q dev server to test developing Q tools",
   "main": "index.js",


### PR DESCRIPTION
- add create-custom-code-item command, which creates a new custom code item in the specified environment and adds it to the q config file